### PR TITLE
sort ft based pid

### DIFF
--- a/Clas12Banks/clas12reader.cpp
+++ b/Clas12Banks/clas12reader.cpp
@@ -202,13 +202,7 @@ namespace clas12 {
 	continue;
       }
     }
-    // //If additional particle sources, add those particles to detParticles
-    // if(_additionalParticleSource.size()){
-    //   for(auto &psource : _additionalParticleSource)
-    // 	while(auto& particle=psource.nextParticle()){
-    // 	  _detParticles.push_back(particle);
-    // 	}
-    // }
+ 
  
   }
   bool clas12reader::passPidSelect(){

--- a/Clas12Banks/clas12reader.h
+++ b/Clas12Banks/clas12reader.h
@@ -69,16 +69,19 @@ namespace clas12 {
       //Forward detector needs particles, calorimeter, scintillator,
       //track, cherenkov
       _rfdets.push_back(std::make_shared<region_fdet>(_bparts,_bftbparts,_bcovmat,_bcal,_bscint,_btrck,_btraj,_bcher,_bft,_bevent));
+      if(_useFTBased)_rfdets.back()->useFTBPid();
     }
      void addARegionCDet(){
       //Forward detector needs particles, calorimeter, scintillator,
       //track, cherenkov
        _rcdets.push_back(std::make_shared<region_cdet>(_bparts,_bftbparts,_bcovmat,_bcal,_bscint,_btrck,_btraj,_bcher,_bft,_bevent));
+       if(_useFTBased)_rcdets.back()->useFTBPid();
     }
     void addARegionFT(){
       //Forward tagger needs particles and forward tagger
       _rfts.push_back(std::make_shared<region_ft>(_bparts,_bftbparts,_bcovmat,_bcal,_bscint,_btrck,_btraj,_bcher,_bft,_bevent));
-    }
+      if(_useFTBased)_rfts.back()->useFTBPid();
+     }
 
 
     const helonline_ptr helonline() const{return _bhelonline;};

--- a/Clas12Banks/ftbparticle.h
+++ b/Clas12Banks/ftbparticle.h
@@ -59,6 +59,7 @@ namespace clas12 {
  
     
     void setEntry(short i){ _entry=i;}
+    void setBankEntry(short i){ _entry=i;} //faster for BankHist
     short getEntry() const {return _entry;}
     /**
     * This is virtual method from hipo::bank it will be called

--- a/Clas12Banks/particle.h
+++ b/Clas12Banks/particle.h
@@ -92,7 +92,7 @@ namespace clas12 {
       return sqrt(x*x+y*y+z*z);
     }
     
-    void setEntry(short i){ _entry=i;if(_ftbpar)_ftbpar->setEntry(i);}
+    void setEntry(short i){ _entry=i;if(_ftbpar.get())_ftbpar->setEntry(i);}
     void setBankEntry(short i){ _entry=i;} //faster for BankHist
     short getEntry() const {return _entry;}
     /**

--- a/Clas12Banks/region_particle.h
+++ b/Clas12Banks/region_particle.h
@@ -61,7 +61,9 @@ namespace clas12 {
        return true;
     }
 
-    int getPid(){_parts->setEntry(_pentry);return _parts->getPid();}
+    int getPid(){_parts->setEntry(_pentry);
+      return _useFTBPid*_ftbparts->getRows()?_ftbparts->getPid():_parts->getPid();
+    }
     
     virtual double getTime()=0;
     virtual double getPath()=0;
@@ -90,6 +92,8 @@ namespace clas12 {
     float getCalcMass();
     float getBeta();
     float getGamma();
+
+    void useFTBPid(){if(_ftbparts.get())_useFTBPid=1;}
     
   protected:
 
@@ -109,7 +113,7 @@ namespace clas12 {
     short _pentry=-1;
     short _pcmat=-1;
     short _region=-1;
-  
+    short _useFTBPid=0;
   };
   //pointer "typedef"
   using region_part_ptr=std::shared_ptr<clas12::region_particle>;

--- a/Clas12Root/BankHist.cpp
+++ b/Clas12Root/BankHist.cpp
@@ -10,7 +10,7 @@ namespace clas12root {
 
     _mapOfParts["BANK"]="bank.";
     _mapOfParts["REC::Particle"]="particle";
-    _mapOfParts["RECFT::Particle"]="particle";
+    _mapOfParts["RECFT::Particle"]="ftbparticle";
     _mapOfParts["REC::Calorimeter"]="calorimeter";
     _mapOfParts["REC::Scintillator"]="scintillator";
     _mapOfParts["REC::Cherenkov"]="cherenkov";

--- a/Clas12Root/BankHist.cpp
+++ b/Clas12Root/BankHist.cpp
@@ -10,6 +10,7 @@ namespace clas12root {
 
     _mapOfParts["BANK"]="bank.";
     _mapOfParts["REC::Particle"]="particle";
+    _mapOfParts["RECFT::Particle"]="particle";
     _mapOfParts["REC::Calorimeter"]="calorimeter";
     _mapOfParts["REC::Scintillator"]="scintillator";
     _mapOfParts["REC::Cherenkov"]="cherenkov";

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Examples are given for running in interactive ROOT sessions and ROOT-Jupyter not
 
 NEW We now use an external hipo4 repository. This must be pointed at with the variable HIPO when installing. The files from hipo/hipo4 will be copied here to Hipo4.
 
-The Hipo c++ reader library can be used independent of specific banks and ROOT, but depends on Hipo.
+For Hipo library see https://github.com/gavalian/hipo 
+
 
 The Clas12Banks implementation can be used independent of ROOT, although currently ROOT dictionaries are created for the classes via cmake (this could be removed). This defines the specific CLAS12 DST banks and provides an interface to the data.
 


### PR DESCRIPTION
Add RECFT::particle to BankHist
Give FTbased Pid flag to region particle. If clas12reader::useFTBased() then getByID() now returns a vector of particles as given by their RECFT based ID if it exists. If there is no RECFT bank or, as can happen, the RECFT bank is empty (presumably no FT hit for the event) then default to standard REC:Particle:Pid.

Note you can still access both from the particle object :
particles[i]->par()->getPid();  or particles[i]->par()->getFTBPid();

But particles[i]->getPid() returns particles[i]->par()->getPid(); unless useFTBased()  in which case  it returns particles[i]->par()->getFTBPid();