### PR TITLE
rcdb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ set(CMAKE_CXX_FLAGS "-fPIC -O3")
 
 
 ##########For local ROOT cmake files comment in the line below and remove the lines commented ##USEROOTSYS
-#######include("cmake/FindROOT.cmake")
+#####include("cmake/FindROOT.cmake")
 list(APPEND CMAKE_PREFIX_PATH $ENV{ROOTSYS}) ############USEROOTSYS
 
 #---Locate the ROOT package and defines a number of variables (e.g. ROOT_INCLUDE_DIRS)

--- a/Clas12Banks/clas12reader.cpp
+++ b/Clas12Banks/clas12reader.cpp
@@ -5,6 +5,7 @@
  */
 
 #include "clas12reader.h"
+#include "vtp.h"
 
 namespace clas12 {
 
@@ -68,11 +69,16 @@ namespace clas12 {
       _bcher.reset(new cherenkov{_factory.getSchema("REC::Cherenkov")});
     if(_factory.hasSchema("REC::ForwardTagger"))
       _bft.reset(new forwardtagger{_factory.getSchema("REC::ForwardTagger")});
+    
+    if(_factory.hasSchema("RAW::vtp"))
+      _bvtp.reset(new clas12::vtp{_factory.getSchema("RAW::vtp")});
 
+    if(_bvtp.get()) cout<<"MAde VTP trigger "<<endl;
+    
     makeListBanks();
-
+    
   }
-
+  
   ///////////////////////////////////////////////////////
   ///read the data
   void clas12reader::clearEvent(){
@@ -147,7 +153,7 @@ namespace clas12 {
     if(_btraj.get())_event.getStructure(*_btraj.get());
     if(_bcher.get())_event.getStructure(*_bcher.get());
     if(_bft.get())_event.getStructure(*_bft.get());
-    //if(_bvtp.get())_event.getStructure(*_bvtp.get());
+    if(_bvtp.get())_event.getStructure(*_bvtp.get());
     //if(_bscal.get())_event.getStructure(*_bscal.get());
 
     for(auto& ibank:_addBanks){//if any additional banks requested get those

--- a/Clas12Banks/clas12reader.cpp
+++ b/Clas12Banks/clas12reader.cpp
@@ -73,7 +73,6 @@ namespace clas12 {
     if(_factory.hasSchema("RAW::vtp"))
       _bvtp.reset(new clas12::vtp{_factory.getSchema("RAW::vtp")});
 
-    if(_bvtp.get()) cout<<"MAde VTP trigger "<<endl;
     
     makeListBanks();
     

--- a/Clas12Banks/clas12reader.h
+++ b/Clas12Banks/clas12reader.h
@@ -164,6 +164,13 @@ namespace clas12 {
     double getRunBeamCharge() const noexcept{ return _runBeamCharge;}
     double getCurrApproxCharge(){return _runBeamCharge*_nevent/_reader.getEntries();}
 
+
+    void getStructure(hipo::bank* bank){
+      if(_isRead==false)
+	hipoRead();
+      _event.getStructure(*bank);
+    }
+    
     protected:
 
     void initReader();

--- a/Clas12Banks/clas12reader.h
+++ b/Clas12Banks/clas12reader.h
@@ -150,6 +150,10 @@ namespace clas12 {
       long pattern = _brunconfig->getTrigger();
       return ( pattern & (1<<k)) != 0;
     }
+    bool checkVTPTriggerBit(uint k){
+      long pattern = _bvtp->makeVTPTriggers();
+      return ( pattern & (1<<k)) != 0;
+    }
 
     scalerreader_ptr scalerReader(){
       if(_scalReader.get()) return _scalReader.get();

--- a/Clas12Banks/scaler.h
+++ b/Clas12Banks/scaler.h
@@ -29,14 +29,7 @@ namespace clas12 {
     float    getFCupGated(){ return getFloat(_fcupgated_order,0); }
     float    getFCup(){ return getFloat(_fcup_order,0); }
     float    getLiveTime(){ return getFloat(_livetime_order,0); }
-     
-    /**
-    * This is virtual method from hipo::bank it will be called
-    * every time a bank is read in the reader. Can be used to sort
-    * particles and or map particles by pid or type (i.e. charge)
-    */
-    //    void notify(){}
-
+ 
   private :
 
     int _fcupgated_order{-1};

--- a/Clas12Banks/vtp.cpp
+++ b/Clas12Banks/vtp.cpp
@@ -14,7 +14,7 @@ namespace clas12 {
     auto sch=getSchema();
     cr_order = sch.getEntryOrder("crate");
     wo_order = sch.getEntryOrder("word");
-   }
+  }
 
   long vtp::makeVTPTriggers() {
 
@@ -28,7 +28,7 @@ namespace clas12 {
     int word1VTP, word2VTP, word3VTP= 0;
     const int trig2VTP=100;
   
-    int Nentries=getSize();
+    int Nentries=getRows();
     int loop1=0;
     while (loop1<Nentries) {
 

--- a/Clas12Banks/vtp.h
+++ b/Clas12Banks/vtp.h
@@ -28,6 +28,8 @@ namespace clas12 {
     
     int    getCrate(int index){ return getInt(cr_order,index); }
     int    getWord(int index){ return getInt(wo_order,index); }
+    int    getCrate(){ return getInt(cr_order,_index); }
+    int    getWord(){ return getInt(wo_order,_index); }
      
     /**
     * This is virtual method from hipo::bank it will be called
@@ -40,11 +42,16 @@ namespace clas12 {
     long  makeVTPTriggers();
     void  decodeVTPTrigger(int word1vtp, int word2vtp);
     void  addVTPTriggerToEvent(long pattern);
+
+    void setBankEntry(short i){ _index=i;} //faster for BankHist
+    void setEntry(int ind){_index=ind;}
+ 
   private :
 
-    int cr_order;
-    int wo_order;
-     
+    int cr_order{-1};
+    int wo_order{-1};
+    int _index{0};
+    
     std::bitset<32> _VTPBitSet;
   };
 

--- a/Clas12Banks/vtp.h
+++ b/Clas12Banks/vtp.h
@@ -36,9 +36,6 @@ namespace clas12 {
     * every time a bank is read in the reader. Can be used to sort
     * particles and or map particles by pid or type (i.e. charge)
     */
-    void notify(){
-      //printf("particle class is read again\n");
-    }
     long  makeVTPTriggers();
     void  decodeVTPTrigger(int word1vtp, int word2vtp);
     void  addVTPTriggerToEvent(long pattern);

--- a/README.md
+++ b/README.md
@@ -380,3 +380,8 @@ An interface to the run conditions database is implemented by the class rcdb_rea
 To try the example
 
        clas12root RunRoot/Ex8_RcdbReader.C+
+
+
+Or edit the file name in Ex8b_RcdbReader.C to get the conditions corresponding to a particular run file.
+
+       clas12root RunRoot/Ex8b_RcdbReader.C+

--- a/RunRoot/Ex1_CLAS12ReaderVTP.C
+++ b/RunRoot/Ex1_CLAS12ReaderVTP.C
@@ -1,0 +1,77 @@
+#include <cstdlib>
+#include <iostream>
+#include <chrono>
+#include <TFile.h>
+#include <TTree.h>
+#include <TApplication.h>
+#include <TROOT.h>
+#include <TDatabasePDG.h>
+#include <TLorentzVector.h>
+#include <TH1.h>
+#include <TChain.h>
+#include <TCanvas.h>
+#include <TBenchmark.h>
+#include "clas12reader.h"
+
+using namespace clas12;
+
+
+void Ex7b_VTP(){
+  // Record start time
+  auto start = std::chrono::high_resolution_clock::now();
+
+
+   TChain fake("hipo");
+   fake.Add(inputFile.Data());
+   //get the hipo data
+   //   reader.open(inputFile.Data());
+   auto files=fake.GetListOfFiles();
+
+  int counter=0;
+ 
+   
+   for(Int_t i=0;i<files->GetEntries();i++){
+     //create the event reader
+     clas12reader c12(files->At(i)->GetTitle(),{0});
+     //  clas12reader c12(files->At(i)->GetTitle(),{0});//add tags {tag1,tag2,tag3,...}
+      
+      //Add some event Pid based selections
+      //////////c12.AddAtLeastPid(211,1); //at least 1 pi+
+      //c12.addExactPid(11,1);    //exactly 1 electron
+      //c12.addExactPid(211,1);    //exactly 1 pi+
+      //c12.addExactPid(-211,1);    //exactly 1 pi-
+      //c12.addExactPid(2212,1);    //exactly 1 proton
+      //c12.addExactPid(22,2);    //exactly 2 gamma
+      //////c12.addZeroOfRestPid();  //nothing else
+      //////c12.useFTBased(); //and use the Pids from RECFT
+
+     //can also access the integrated current at this point
+     //c12.scalerReader();//must call this first
+     //c12.getRunBeamCharge();
+     
+      while(c12.next()==true){
+	//can get an estimate of the beam current to this event
+	//c12.getCurrApproxCharge();//if called c12.scalerReader();
+	
+        //c12.event()->getStartTime();
+
+	if(c12.event()->checkTriggerBit(24)){
+	  for(Int_t ivtp=0;i<c12.event()->vtp()->getRows();ivtp++)
+	    cout<<ivtp<<" VTP word "<<c12.event()->vtp()->getWord(ivtp)<<" "<<" VTP crate "<<c12.event()->vtp()->getCrate(ivtp)<<" "<<endl;
+	  cout<<"VTP trigger pattern "<<c12.event()->vtp()->makeVTPTriggers()<<endl;
+	  
+	}
+	
+  
+       
+	counter++;
+      }
+      
+   }
+
+  
+   auto finish = std::chrono::high_resolution_clock::now();
+   std::chrono::duration<double> elapsed = finish - start;
+   std::cout << "Elapsed time: " << elapsed.count()<< " events = "<<counter<< " s\n";
+
+}

--- a/RunRoot/Ex7b_VTP.C
+++ b/RunRoot/Ex7b_VTP.C
@@ -1,0 +1,65 @@
+#include <cstdlib>
+#include <iostream>
+#include <chrono>
+#include <TFile.h>
+#include <TTree.h>
+#include <TApplication.h>
+#include <TROOT.h>
+#include <TDatabasePDG.h>
+#include <TLorentzVector.h>
+#include <TH1.h>
+#include <TChain.h>
+#include <TCanvas.h>
+#include <TBenchmark.h>
+#include "clas12reader.h"
+
+using namespace clas12;
+
+
+void Ex7b_VTP(){
+ 
+ 
+  int counter=0;
+ 
+   
+  clas12reader c12("/work/jlab/clas12data/pass0/skim3_005424.hipo",{0});
+     //  clas12reader c12(files->At(i)->GetTitle(),{0});//add tags {tag1,tag2,tag3,...}
+  
+      //Add some event Pid based selections
+      //////////c12.AddAtLeastPid(211,1); //at least 1 pi+
+      //c12.addExactPid(11,1);    //exactly 1 electron
+      //c12.addExactPid(211,1);    //exactly 1 pi+
+      //c12.addExactPid(-211,1);    //exactly 1 pi-
+      //c12.addExactPid(2212,1);    //exactly 1 proton
+      //c12.addExactPid(22,2);    //exactly 2 gamma
+      //////c12.addZeroOfRestPid();  //nothing else
+      //////c12.useFTBased(); //and use the Pids from RECFT
+
+     //can also access the integrated current at this point
+     //c12.scalerReader();//must call this first
+     //c12.getRunBeamCharge();
+     
+      while(c12.next()==true){
+	//can get an estimate of the beam current to this event
+	//c12.getCurrApproxCharge();//if called c12.scalerReader();
+	
+        //c12.event()->getStartTime();
+
+	if(c12.checkTriggerBit(24)){
+	  cout<<"Got mesonex trigger "<<endl;
+	  for(Int_t ivtp=0;ivtp<c12.vtp()->getRows();ivtp++){
+	
+	    cout<<ivtp<<" VTP word "<<c12.vtp()->getWord(ivtp)<<" "<<" VTP crate "<<c12.vtp()->getCrate(ivtp)<<" "<<endl;
+	    cout<<"VTP trigger pattern "<<c12.vtp()->makeVTPTriggers()<<endl;
+	    cout<<"VTP trigger BIT 10"<<c12.checkVTPTriggerBit(10)<<endl;
+	  }
+	}
+       
+	counter++;
+      }
+      
+   
+
+  
+  
+}

--- a/RunRoot/Ex8b_RcdbReader.C
+++ b/RunRoot/Ex8b_RcdbReader.C
@@ -1,0 +1,45 @@
+#include <cstdlib>
+#include <iostream>
+#include "rcdb_reader.h"
+#include "clas12reader.h"
+#include <string>
+#include <chrono>
+#include <ctime>
+
+using namespace clas12;
+using namespace std;
+
+void Ex8b_RcdbReader(){
+
+
+  clas12reader c12("/a/hipo/file.hipo",{0});//needs tag-0 event
+  c12.next();//need to read first event
+  auto runNo=c12.runconfig()->getRun(); //get run number for this file
+  c12.getReader().gotoRecord(0); //reset back to start
+  
+  /* Creates the interface to RCDB header library.
+   * Immediately opens a connection to rcdb@clasdb.jlab.org/rcdb.
+   */
+  rcdb_reader rcdb;
+
+  /* Examples of how to access different conditions for runNo.
+   * If the wrong type is asked for a given condition the code will 
+   * stop running.
+   * If the run or condition doesn't exist an error message is given 
+   * and a wrong value is returned.
+   * The database and conditions can be viewed at 
+   * https://clasweb.jlab.org/rcdb/ .
+   */
+  int val = rcdb.getIntValue(runNo, "event_count");
+  double val2 = rcdb.getDoubleValue(runNo, "beam_energy");
+  double val3 = rcdb.getDoubleValue(runNo, "beam_current");
+  std::string val4 = rcdb.getStringValue(runNo, "target");
+  bool val5 = rcdb.getBoolValue(runNo, "is_valid_run_end");
+
+  cout<<"Run number : "<<runNo<<endl;
+  cout<<"Event count: "<<val<<" Beam energy: "<<val2<<endl;
+  cout<<"Beam current: "<<val3<<" Target: "<<val4<<endl;
+  cout<<"Run is valid: "<<val5<<endl;
+
+
+}

--- a/hipo4/CMakeLists.txt
+++ b/hipo4/CMakeLists.txt
@@ -1,6 +1,8 @@
 
 ROOT_GENERATE_DICTIONARY(G__Hipo4  reader.h bank.h writer.h  ntuple_writer.h ntuple_reader.h LINKDEF HipoLinkDef.h)
 
+#ROOT_GENERATE_DICTIONARY(G__Hipo4  reader.h bank.h writer.h LINKDEF HipoLinkDef.h)
+
 add_library(Hipo4 SHARED utils.cpp dictionary.cpp  event.cpp record.cpp recordbuilder.cpp reader.cpp bank.cpp writer.cpp ntuple_writer.cpp ntuple_reader.cpp  G__Hipo4.cxx)
 
 if( ${CMAKE_SYSTEM_NAME} MATCHES "Darwin")


### PR DESCRIPTION
Note to use rcdb you also need to load module gcc/4.9.2 on ifarm

Richard Tyson ,
This introduces the rcdb_reader class which is an interface to the RCDB c++ code from https://github.com/JeffersonLab/rcdb . More instruction on how to run the code is found here https://github.com/JeffersonLab/rcdb/wiki/Cpp.

The rcdb_reader will open a connection to rcdb@clasdb.jlab.org/rcdb and allow for the values of conditions to be returned for a given run. It uses several functions of format getTYPEValue(runNb, condition), where type is one of bool, int, double, string, time_point. If the condition or the run don't exist then the functions will print an error message and return a wrong value. It's left to the user to notice the error message and that the value is wrong. If the TYPE is wrong for the condition an error is thrown by the RCDB c++ code which will stop the program.

An example of the rcdb_reader is given in RunRoot/Ex8_RcdbReader.C, and the database can be viewed at https://clasweb.jlab.org/rcdb/.
Note: The only conditions that use a time_point are run_start_time and run_end_time. Currently they seem to return the UNIX start time (ie January 1st 1970), which happens if a time_point isn't initialised. This is true for the rcdb_reader but also by just using the RCDB code. You can try this in the simple example in rcdb/cpp/examples/simple.cpp with:
auto cnd2 = connection.GetCondition(run, "run_start_time");
chrono::time_pointchrono::system_clock val6 = cnd2->ToTime();
time_t ttp = chrono::system_clock::to_time_t(val6);
cout<<"start time: "<<ctime(&ttp)<<endl;
I'm sure the conversion from time_point to time_t works, you can try it by replacing cnd2->ToTime(); with chrono::system_clock::now();.
This probably means there's a bug either in the rcdb code or the actual database (although the start times look right). In any case, although I've given the option to ask for a time_point I haven't included it in the example.

The CMake code will first check if the environment variable RCDB_HOME is set. If it isn't the case we assume that the user doesn't want to use the rcdb_reader and the rcdb_reader class won't be compiled, and the RCDB library won't be included. This means that users can update their version of clas12root without having to download the RCDB library. The CMake code will then check that MySQL is installed on the user's system, find the path to the relevant include and libraries and add them. If the user doesn't have MySQL this won't stop clas12root from compiling.

I've also update the readme to provide instruction on how to get the RCDB library and compile clas12root correctly.