### PR TITLE
Change rcdb access

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,31 +36,7 @@ add_definitions(-D__LZ4__)
 #after Lz4 change include to include
 set(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
-#include rcdb c++ header library
-IF (DEFINED ENV{RCDB_HOME})
-  include_directories($ENV{RCDB_HOME}/cpp/include)
-ENDIF (DEFINED ENV{RCDB_HOME})
 
-#find path to mysql include directory
-FIND_PATH(MYSQL_INCLUDE_DIR mysql.h
-  /usr/local/include/mysql
-  /usr/include/mysql
-  )
-
-#find path to mysql library
-SET(MYSQL_NAMES mysqlclient mysqlclient_r)
-FIND_LIBRARY(MYSQL_LIBRARY
-  NAMES ${MYSQL_NAMES}
-  PATHS /usr/lib /usr/local/lib /usr/lib64 /usr/local/lib64
-  PATH_SUFFIXES mysql
-  )
-
-#include mysql library and directory if they were found
-IF (MYSQL_INCLUDE_DIR AND MYSQL_LIBRARY)
-  include_directories(${MYSQL_INCLUDE_DIR})
-  link_libraries(${MYSQL_LIBRARY})
-  add_definitions(-DRCDB_MYSQL)
-ENDIF (MYSQL_INCLUDE_DIR AND MYSQL_LIBRARY)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/hipo4)
 add_subdirectory (${CMAKE_CURRENT_SOURCE_DIR}/hipo4)

--- a/Clas12Banks/CMakeLists.txt
+++ b/Clas12Banks/CMakeLists.txt
@@ -1,3 +1,29 @@
+#include rcdb c++ header library
+IF (DEFINED ENV{RCDB_HOME})
+  include_directories($ENV{RCDB_HOME}/cpp/include)
+  #find path to mysql include directory
+  FIND_PATH(MYSQL_INCLUDE_DIR mysql.h
+    /usr/local/include/mysql
+    /usr/include/mysql
+    )
+
+  #find path to mysql library
+  SET(MYSQL_NAMES mysqlclient mysqlclient_r)
+  FIND_LIBRARY(MYSQL_LIBRARY
+    NAMES ${MYSQL_NAMES}
+    PATHS /usr/lib /usr/local/lib /usr/lib64 /usr/local/lib64
+    PATH_SUFFIXES mysql
+    )
+
+  #include mysql library and directory if they were found
+  IF (MYSQL_INCLUDE_DIR AND MYSQL_LIBRARY)
+    include_directories(${MYSQL_INCLUDE_DIR})
+    link_libraries(${MYSQL_LIBRARY})
+    add_definitions(-DRCDB_MYSQL)
+  ENDIF (MYSQL_INCLUDE_DIR AND MYSQL_LIBRARY)
+
+ENDIF (DEFINED ENV{RCDB_HOME})
+
 #Only compile rcdb_reader if the path to RCDB library is set in RCDB_HOME.
 IF (DEFINED ENV{RCDB_HOME})
 

--- a/Clas12Banks/clas12reader.cpp
+++ b/Clas12Banks/clas12reader.cpp
@@ -9,7 +9,9 @@
 
 namespace clas12 {
 
-  clas12reader::clas12reader(std::string filename,std::vector<long> tags):_filename(filename){
+  clas12reader::clas12reader(std::string filename,std::vector<long> tags):
+    _filename(filename){
+
     cout<<" clas12reader::clas12reader reading "<<filename.data()<<endl;
     _reader.setTags(tags);
  
@@ -19,7 +21,9 @@ namespace clas12 {
   ///copy constructor
   ///opens a new reader
   ///Can give alternative filename
-  clas12reader::clas12reader(const clas12reader &other,std::string filename,std::vector<long> tags):_filename(filename){
+  clas12reader::clas12reader(const clas12reader &other,std::string filename,
+			     std::vector<long> tags):_filename(filename){
+    
     cout<<" clas12reader::clas12reader reading "<<filename.data()<<endl;
 
     //if default filename take same file as original
@@ -33,13 +37,13 @@ namespace clas12 {
     _pidSelect=other._pidSelect;
     _pidSelectExact=other._pidSelectExact;
     _zeroOfRestPid=other._zeroOfRestPid;
-    _useFTBased=other._useFTBased;;
+    _useFTBased=other._useFTBased;
 
   }
   void clas12reader::initReader(){
-   _reader.open(_filename.data()); //keep a pointer to the reader
+    _reader.open(_filename.data()); //keep a pointer to the reader
 
-    // hipo::dictionary  factory;
+      // hipo::dictionary  factory;
     _reader.readDictionary(_factory);
 
     //initialise banks pointers
@@ -76,45 +80,51 @@ namespace clas12 {
     
     makeListBanks();
     
-    #ifdef RCDB_MYSQL
-    queryRcdb();
-    #endif
-    
+  
+
   }
 
+  ///////////////////////////////////////////////////////////////////////
+  ///Basically get the run number!
+  ///will open and close a hipo file
+  int  clas12reader::readQuickRunConfig(const std::string& filename) {
+    hipo::reader     areader;
+    hipo::event      anevent;
+    hipo::dictionary  afactory;
+    
+    areader.setTags(0);
+    areader.open(filename.data()); //keep a pointer to the reader
+    areader.readDictionary(afactory);
+    
+    clas12::runconfig  arunconf(afactory.getSchema("RUN::config"));
+
+    areader.next();
+    areader.read(anevent);
+    anevent.getStructure(arunconf);
+
+    int runNo=arunconf.getRun();
+  
+    std::cout<<"Found run number : "<<runNo<<std::endl;
+    return runNo;
+  }
   ///////////////////////////////////////////////////////////////////////
   ///Function to query RCDB and record most relevant run conditions.
   ///This is only called once to avoid overloading the database.
   void clas12reader::queryRcdb(){
-    next();//need to read first event
-    auto runNo=runconfig()->getRun(); //get run number for this file
-    getReader().gotoRecord(0); //reset back to start
-    rcdb_reader rcdb; //initialise rcdb_reader
+    if(_rcdbQueried==true) return; //only allowed to call once
+    _rcdbQueried=true;
 
-    //Incomplete list of run conditions.
-    //If you add to this list please add values and names in the same order.
-    _conditionValues.push_back(rcdb.getDoubleValue(runNo, "event_count"));
-    _conditionNames.push_back("event_count");
-    _conditionValues.push_back(rcdb.getDoubleValue(runNo, "beam_energy"));
-    _conditionNames.push_back("beam_energy");
-    _conditionValues.push_back(rcdb.getDoubleValue(runNo, "beam_current"));
-    _conditionNames.push_back("beam_current");
-
-    //Close connection to database.
-    rcdb.Close();
+#ifdef RCDB_MYSQL
+    _runNo=readQuickRunConfig(_filename);
     
+    rcdb_reader rc; //initialise rcdb_reader
+    
+    //For full list see https://clasweb.jlab.org/rcdb/conditions/
+    _rcdbVals = rc.readAll(_runNo,getFilename());
+#endif
+    //rcdb connection closed when rc goes out of scope here 
   }
 
-  /////////////////////////////////////////////////////////////////////////
-  ///Function to return a condition value for a given condition name.
-  double clas12reader::getRunCondition(std::string condition){
-    for (int i=0; i<_conditionNames.size();i++){
-      if(_conditionNames[i] == condition){
-	return _conditionValues[i];
-      }
-    }
-    return 0;
-  }
   
   ///////////////////////////////////////////////////////
   ///read the data

--- a/Clas12Banks/clas12reader.cpp
+++ b/Clas12Banks/clas12reader.cpp
@@ -76,6 +76,44 @@ namespace clas12 {
     
     makeListBanks();
     
+    #ifdef RCDB_MYSQL
+    queryRcdb();
+    #endif
+    
+  }
+
+  ///////////////////////////////////////////////////////////////////////
+  ///Function to query RCDB and record most relevant run conditions.
+  ///This is only called once to avoid overloading the database.
+  void clas12reader::queryRcdb(){
+    next();//need to read first event
+    auto runNo=runconfig()->getRun(); //get run number for this file
+    getReader().gotoRecord(0); //reset back to start
+    rcdb_reader rcdb; //initialise rcdb_reader
+
+    //Incomplete list of run conditions.
+    //If you add to this list please add values and names in the same order.
+    _conditionValues.push_back(rcdb.getDoubleValue(runNo, "event_count"));
+    _conditionNames.push_back("event_count");
+    _conditionValues.push_back(rcdb.getDoubleValue(runNo, "beam_energy"));
+    _conditionNames.push_back("beam_energy");
+    _conditionValues.push_back(rcdb.getDoubleValue(runNo, "beam_current"));
+    _conditionNames.push_back("beam_current");
+
+    //Close connection to database.
+    rcdb.Close();
+    
+  }
+
+  /////////////////////////////////////////////////////////////////////////
+  ///Function to return a condition value for a given condition name.
+  double clas12reader::getRunCondition(std::string condition){
+    for (int i=0; i<_conditionNames.size();i++){
+      if(_conditionNames[i] == condition){
+	return _conditionValues[i];
+      }
+    }
+    return 0;
   }
   
   ///////////////////////////////////////////////////////

--- a/Clas12Banks/clas12reader.h
+++ b/Clas12Banks/clas12reader.h
@@ -37,6 +37,7 @@
 #include "region_cdet.h"
 #include "region_ft.h"
 #include "scaler_reader.h"
+#include "rcdb_vals.h"
 
 #include "dictionary.h"
 
@@ -175,8 +176,9 @@ namespace clas12 {
     }
 
     //rcdb
-    double getRunCondition(std::string condition);
-    
+    static int readQuickRunConfig(const std::string& filename);
+   void queryRcdb();
+ 
     protected:
 
     void initReader();
@@ -184,11 +186,7 @@ namespace clas12 {
     
     private:
 
-    //rcdb
-    void queryRcdb();
-    std::vector<double> _conditionValues;
-    std::vector<std::string> _conditionNames;
-
+    
     void hipoRead(){
       _reader.read(_event);
       _isRead=true;
@@ -235,7 +233,7 @@ namespace clas12 {
     //this vector links to raw ptrs, does not own
     std::vector<region_part_ptr> _detParticles;
 
-
+     
     double _runBeamCharge{0};
     long _nevent{0};
     ushort _nparts{0};
@@ -245,7 +243,8 @@ namespace clas12 {
 
     std::vector<short> _pids;
     bool _isRead{false};
-
+    bool _rcdbQueried=false;
+    
     //members that need copied in constructor
     scalerreader_uptr _scalReader;
     std::vector<short> _givenPids;
@@ -253,6 +252,23 @@ namespace clas12 {
     std::map<short,short> _pidSelectExact;
     bool _zeroOfRestPid{false};
     bool _useFTBased{false};
+
+       //rcdb
+    int _runNo{0};
+    
+    ///////////////////////////////RCDB
+   private:
+
+    rcdb_vals _rcdbVals;
+
+  public:
+
+    const rcdb_vals& getRcdbVals(){return _rcdbVals;}
+    void setRcdbVals(const rcdb_vals& vals){_rcdbVals=vals;}
+    
+  private:
+ ///////////////////////////////
+
    };
   //helper functions
   

--- a/Clas12Banks/clas12reader.h
+++ b/Clas12Banks/clas12reader.h
@@ -45,6 +45,9 @@
 #include <string>
 #include <iostream>
 
+#ifdef RCDB_MYSQL
+   #include "rcdb_reader.h"
+#endif
 
 namespace clas12 {
   using std::cout;
@@ -170,6 +173,9 @@ namespace clas12 {
 	hipoRead();
       _event.getStructure(*bank);
     }
+
+    //rcdb
+    double getRunCondition(std::string condition);
     
     protected:
 
@@ -177,6 +183,11 @@ namespace clas12 {
     
     
     private:
+
+    //rcdb
+    void queryRcdb();
+    std::vector<double> _conditionValues;
+    std::vector<std::string> _conditionNames;
 
     void hipoRead(){
       _reader.read(_event);

--- a/Clas12Banks/rcdb_reader.cpp
+++ b/Clas12Banks/rcdb_reader.cpp
@@ -4,8 +4,11 @@ namespace clas12 {
 
   /* Empty constructor needed to link _connection to database.
    */
-  rcdb_reader::rcdb_reader(){}
-
+  rcdb_reader::rcdb_reader():_connection{"mysql://rcdb@clasdb.jlab.org/rcdb", true}{}
+   /* explicit close in destructor.
+   */
+  rcdb_reader::~rcdb_reader(){close();};
+  
   /* Function to return a bool type value, given the value's name and a run
    * number.
    * Will return false if the condition doesn't exist for this run, or the run
@@ -13,7 +16,7 @@ namespace clas12 {
    * If the value is not of type bool the program will stop.
    */
   bool rcdb_reader::getBoolValue(int runNb, std::string value){
-    auto cnd = _connection->GetCondition(runNb, value);
+    auto cnd = _connection.GetCondition(runNb, value);
     bool val = false;
     if(!cnd){
       cout<<"The condition "<<value<<" does not exist for run "<<runNb<<"."<<endl;
@@ -37,7 +40,7 @@ namespace clas12 {
    * If the value is not of type integer the program will stop.
    */
   int rcdb_reader::getIntValue(int runNb, std::string value){
-    auto cnd = _connection->GetCondition(runNb, value);
+    auto cnd = _connection.GetCondition(runNb, value);
     int val = -1;
     if(!cnd){
       cout<<"The condition "<<value<<" does not exist for run "<<runNb<<"."<<endl;
@@ -61,7 +64,7 @@ namespace clas12 {
    * If the value is not of type double the program will stop.
    */
   double rcdb_reader::getDoubleValue(int runNb, std::string value){
-    auto cnd = _connection->GetCondition(runNb, value);
+    auto cnd = _connection.GetCondition(runNb, value);
     double val = -1;
     if(!cnd){
       cout<<"The condition "<<value<<" does not exist for run "<<runNb<<"."<<endl;
@@ -85,7 +88,7 @@ namespace clas12 {
    * If the value is not of type string the program will stop.
    */
   std::string rcdb_reader::getStringValue(int runNb, std::string value){
-    auto cnd = _connection->GetCondition(runNb, value);
+    auto cnd = _connection.GetCondition(runNb, value);
     std::string val = "Error";
     if(!cnd){
       cout<<"The condition "<<value<<" does not exist for run "<<runNb<<"."<<endl;
@@ -109,7 +112,7 @@ namespace clas12 {
    * If the value is not of type time_point the program will stop.
    */
   std::chrono::time_point<std::chrono::system_clock> rcdb_reader::getTimeValue(int runNb, std::string value){
-    auto cnd = _connection->GetCondition(runNb, value);
+    auto cnd = _connection.GetCondition(runNb, value);
     std::chrono::time_point<std::chrono::system_clock> val = std::chrono::system_clock::now();
     if(!cnd){
       cout<<"The condition "<<value<<" does not exist for run "<<runNb<<"."<<endl;
@@ -125,4 +128,43 @@ namespace clas12 {
     }
     return val;
     }
+
+  /* Function to read all conditions given in https://clasweb.jlab.org/rcdb/conditions/
+     returns a copy of all vals
+   */
+  rcdb_vals rcdb_reader::readAll(int runNb,const string& filename){
+    rcdb_vals fetcher;
+    fetcher.run_number=runNb;//additional keep the run number
+    fetcher.beam_current=getDoubleValue(runNb, "beam_current");
+    fetcher.beam_energy=getDoubleValue(runNb, "beam_energy");
+    fetcher.events_rate=getDoubleValue(runNb, "events_rate");
+    fetcher.solenoid_current=getDoubleValue(runNb, "solenoid_current");
+    fetcher.solenoid_scale=getDoubleValue(runNb, "solenoid_scale");
+    fetcher.target_position=getDoubleValue(runNb, "target_position");
+    fetcher.test=getDoubleValue(runNb, "test");
+    fetcher.torus_current=getDoubleValue(runNb, "torus_current");
+    fetcher.torus_scale=getDoubleValue(runNb, "torus_scale");
+    
+    fetcher.event_count=getIntValue(runNb, "event_count");
+    fetcher.evio_files_count=getIntValue(runNb, "evio_files_count");
+    fetcher.half_wave_plate=getIntValue(runNb, "half_wave_plate");
+    fetcher.megabyte_count=getIntValue(runNb, "megabyte_count");
+    fetcher.status=getIntValue(runNb, "status");
+    fetcher.temperature=getIntValue(runNb, "temperature");
+
+    fetcher.file_name=filename;
+    fetcher.beam_current_request=getStringValue(runNb, "beam_current_request");
+    fetcher.daq_comment=getStringValue(runNb, "daq_comment");
+    fetcher.daq_config=getStringValue(runNb, "daq_config");
+    fetcher.daq_setup=getStringValue(runNb, "daq_setup");
+    fetcher.daq_trigger=getStringValue(runNb, "daq_trigger");
+    fetcher.operators=getStringValue(runNb, "operators");
+    fetcher.run_type=getStringValue(runNb, "run_type");
+    fetcher.target=getStringValue(runNb, "target");
+    fetcher.user_comment=getStringValue(runNb, "user_comment");
+     
+    return fetcher;
+  }
+
+  
 }

--- a/Clas12Banks/rcdb_reader.h
+++ b/Clas12Banks/rcdb_reader.h
@@ -28,6 +28,7 @@ namespace clas12 {
     double getDoubleValue(int runNb, std::string value);
     std::string getStringValue(int runNb, std::string value);
     std::chrono::time_point<std::chrono::system_clock> getTimeValue(int runNb, std::string value);
+    void Close(){_connection->Close();};
 
   private:
 

--- a/Clas12Banks/rcdb_reader.h
+++ b/Clas12Banks/rcdb_reader.h
@@ -6,6 +6,8 @@
 #ifndef RCDB_READER_H
 #define RCDB_READER_H
 
+#include "rcdb_vals.h"
+
 #include "RCDB/Connection.h" 
 #include <iostream>
 
@@ -15,27 +17,30 @@
 namespace clas12 {
   using std::cout;
   using std::endl;
+  using std::string;
 
+  
   class rcdb_reader {
 
   public:
 
     rcdb_reader();
-    virtual ~rcdb_reader()=default;
+    virtual ~rcdb_reader();
 
     bool getBoolValue(int runNb, std::string value);
     int getIntValue(int runNb, std::string value);
     double getDoubleValue(int runNb, std::string value);
     std::string getStringValue(int runNb, std::string value);
     std::chrono::time_point<std::chrono::system_clock> getTimeValue(int runNb, std::string value);
-    void Close(){_connection->Close();};
+    void close(){_connection.Close();};
 
+    rcdb_vals readAll(int runNb,const string& filename);
+    
   private:
 
-    rcdb::Connection *_connection = new rcdb::Connection("mysql://rcdb@clasdb.jlab.org/rcdb", true);    
-
+    rcdb::Connection _connection;    
   };
+  
 
 }
-
 #endif /* RCDB_READER_H */

--- a/Clas12Banks/rcdb_vals.h
+++ b/Clas12Banks/rcdb_vals.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include <string>
+
+namespace clas12 {
+  using std::string;
+
+  struct rcdb_vals{
+    string	file_name{""};	//data file name used to read the rcdb
+    string	beam_current_request{""};	//Beam Current Request
+    string	daq_comment{""};	//DAQ comment
+    string	daq_config{""};	//Run config on main page
+    string	daq_setup{""};	//Run type on main page
+    string	daq_trigger{""};	//Trigger file
+    string	operators{""};	
+    string	run_config{""};	//DAQ/Trigger config file
+    string	run_type{""};	//Run Type
+    string	target{""};	//Target
+    string	user_comment{""};//
+    float	beam_current{0};	//Beam current
+    float	beam_energy{0};	//Beam Energy
+    float	events_rate{0};	//Daq events rate
+    float	solenoid_current{0};	//Solenoid current
+    float	solenoid_scale{0};  //Solenoid scale factor
+    float	target_position{0};	//Target position
+    float	test{0};	//Beam test
+    float	torus_current{0};	//Torus current
+    float	torus_scale{0};	//Torus scale factor
+    int         run_number{0}; //given run number (not actually from rcdb)
+    int	        event_count{0};	//Number of events in run
+    int 	evio_files_count{0};	//The number of data files
+    int 	half_wave_plate{0};	//Half Wave Plate position
+    int 	megabyte_count{0};	//The number of megabytes in run
+    int 	status{0};	//Run Status
+    int 	temperature{0};	//Temperature of the Sun
+    bool	is_valid_run_end{1};	//True if a run has valid run-end record. False means the run was aborted/crashed at some point
+  };
+}

--- a/Clas12Root/CMakeLists.txt
+++ b/Clas12Root/CMakeLists.txt
@@ -2,6 +2,32 @@ set(CLAS12ROOT Clas12Root)
 set(CLAS12BANKS Clas12Banks)
 set(HIPO Hipo4)
 
+#include rcdb c++ header library
+IF (DEFINED ENV{RCDB_HOME})
+  include_directories($ENV{RCDB_HOME}/cpp/include)
+  #find path to mysql include directory
+  FIND_PATH(MYSQL_INCLUDE_DIR mysql.h
+    /usr/local/include/mysql
+    /usr/include/mysql
+    )
+
+  #find path to mysql library
+  SET(MYSQL_NAMES mysqlclient mysqlclient_r)
+  FIND_LIBRARY(MYSQL_LIBRARY
+    NAMES ${MYSQL_NAMES}
+    PATHS /usr/lib /usr/local/lib /usr/lib64 /usr/local/lib64
+    PATH_SUFFIXES mysql
+    )
+
+  #include mysql library and directory if they were found
+  IF (MYSQL_INCLUDE_DIR AND MYSQL_LIBRARY)
+    include_directories(${MYSQL_INCLUDE_DIR})
+    link_libraries(${MYSQL_LIBRARY})
+    add_definitions(-DRCDB_MYSQL)
+  ENDIF (MYSQL_INCLUDE_DIR AND MYSQL_LIBRARY)
+
+ENDIF (DEFINED ENV{RCDB_HOME})
+
 ROOT_GENERATE_DICTIONARY(G__${CLAS12ROOT}  BankHist.h HipoHist.h HipoTreeMaker.h HipoChain.h HipoRootAction.h   HipoROOTOut.h ParticleHist.h HipoSelector.h ParticleTree.h LINKDEF Clas12RootLinkDef.h)
 
 add_library(${CLAS12ROOT} SHARED BankHist.cpp HipoHist.cpp HipoTreeMaker.cpp HipoChain.cpp HipoRootAction.cpp   HipoROOTOut.cpp ParticleHist.cpp  HipoSelector.cpp ParticleTree.cpp G__${CLAS12ROOT}.cxx)

--- a/Clas12Root/HipoChain.h
+++ b/Clas12Root/HipoChain.h
@@ -2,11 +2,17 @@
 
 
 #include "clas12reader.h"
+#include "TRcdbVals.h"
 
 #include <TNamed.h>
 #include <TChain.h>
 #include <TObjArray.h>
 #include <TString.h>
+#include <TSystem.h>
+
+#ifdef RCDB_MYSQL
+   #include "rcdb_reader.h"
+#endif
 
 namespace clas12root {
 
@@ -17,6 +23,11 @@ namespace clas12root {
   public :
     HipoChain();
     virtual ~HipoChain()=default;
+    HipoChain(const HipoChain& other) = default; //Copy Constructor
+    HipoChain(HipoChain&& other) = default; //Move Constructor
+      
+    HipoChain& operator=(const HipoChain& other)=default;
+    HipoChain& operator=(HipoChain&& other)=default;
 
 
     void Add(TString name);
@@ -50,6 +61,20 @@ namespace clas12root {
 
     void AddBeamCharge(Double_t bc){_totBeamCharge+=bc;}
     Double_t TotalBeamCharge() const noexcept{return _totBeamCharge;}
+
+
+
+///////////////////////////////RCDB
+    void WriteRcdbData(TString filename);
+    clas12::rcdb_vals FetchRunRcdb(const TString& datafile);
+
+    void SetRcdbFile(const TString& filename ){
+      //needs full path for PROOF
+      if(filename.BeginsWith("/")==kFALSE&&filename.BeginsWith("$")==kFALSE)
+	_rcdbFileName = TString(gSystem->Getenv("PWD"))+"/"+filename;
+      else _rcdbFileName=filename;
+    }
+///////////////////////////////
     
   private :
     TChain _tchain;
@@ -66,7 +91,11 @@ namespace clas12root {
     Int_t _idxFile{0};
 
     Double_t _totBeamCharge{0};
+
+    TString _rcdbFileName;
     
     ClassDef(clas12root::HipoChain,1);
   };
+
+ 
 }

--- a/Clas12Root/HipoSelector.h
+++ b/Clas12Root/HipoSelector.h
@@ -33,7 +33,8 @@ namespace clas12root{
       void    Begin(TTree *tree) override;
       void    SlaveBegin(TTree *tree) override;
       Bool_t  Process(Long64_t entry) override;
-     
+      Bool_t  Notify() override;
+      
       virtual Bool_t ProcessEvent() =  0; //loop action to be defined in derived class
 
       virtual void AddFilter(){};
@@ -41,7 +42,9 @@ namespace clas12root{
   protected:
       
       std::unique_ptr<clas12::clas12reader> _c12;//!
- 
+
+      void Rcdb();
+      
     private:
 
       HipoChain* _chain{nullptr};

--- a/Clas12Root/TRcdbVals.h
+++ b/Clas12Root/TRcdbVals.h
@@ -1,0 +1,24 @@
+#pragma once
+#include "rcdb_vals.h"
+#include <TNamed.h>
+
+namespace clas12root {
+  ///////////////////////////////RCDB
+  class TRcdbVals : public TNamed{
+
+  public :
+    TRcdbVals()=default;
+ 
+  TRcdbVals(clas12::rcdb_vals vals):_data{vals} {};
+    const char* GetTitle() const final{return _data.file_name.data();}
+    const char* GetName() const final{return Form("Run_%d", _data.run_number);}
+
+    clas12::rcdb_vals _data{};
+
+    ClassDef(clas12root::TRcdbVals,1);
+  };
+#pragma link C++ class clas12root::TRcdbVals+;
+#pragma link C++ class clas12::rcdb_vals+;
+}
+
+///////////////////////////////   

--- a/README.md
+++ b/README.md
@@ -397,13 +397,29 @@ Click on the notebook CLAS12Writer3Pi.ipynb and follow the tutorial
 
 ## Ex 8 Reading from the Run Conditions DataBase
 
-An interface to the run conditions database is implemented by the class rcdb_reader. It will open a connection to rcdb@clasdb.jlab.org/rcdb and allow you to retrieve condition values for a given run. This class interfaces to the Run Conditions DataBase c++ code, more information on it can be found at https://github.com/JeffersonLab/rcdb/wiki/Cpp and the database itself can be viewed at https://clasweb.jlab.org/rcdb/. An example on how to use the rcdb_reader interface can be found in RunRoot/Ex8_RcdbReader.C
+clas12reader can make a connection to the RCDB database and download the relevent information for a run. The downloaded information can be accessed via a rcdb_vals struct,
+
+      clas12reader c12("/a/hipo/file.hipo");
+      c12.queryRcdb(); //only check rcdb values when asked to (and RCDB_HOME was set)
+      auto rcdbData=c12.getRcdbVals();//struct with all relevent rcdb values
+      auto energy = rcdbData.beam_energy;
+      
+An interface to the run conditions database is implemented by the class rcdb_reader. It will open a connection to rcdb@clasdb.jlab.org/rcdb and allow you to retrieve condition values for a given run. This class interfaces to the Run Conditions DataBase c++ code, more information on it can be found at https://github.com/JeffersonLab/rcdb/wiki/Cpp and the database itself can be viewed at https://clasweb.jlab.org/rcdb/. A full list of the relevent variables can be found at https://clasweb.jlab.org/rcdb/conditions/
+
+An example on how to use the raw rcdb_reader interface can be found in RunRoot/Ex8_RcdbReader.C. But users should just use the clas12reader functions rather than handling rcdb_reader directly to limit the number of connections and queries as given in Ex8b_RcdbReader.C.
+
 
 To try the example
 
-       clas12root RunRoot/Ex8_RcdbReader.C+
-
-
-Or edit the file name in Ex8b_RcdbReader.C to get the conditions corresponding to a particular run file.
-
        clas12root RunRoot/Ex8b_RcdbReader.C+
+ 
+In the case where many files are to be analysed use of HipoChain is recommended and this includes some rcdb features. Once a chain of file is created it can be used to access the RCDB and download the info for those files. This information is then saved locally in a root file which can be used directly when processing the HipoChain. Reading of the local rcdb file is then already automated in HipoSelector
+
+      clas12root::HipoChain chain;
+      chain.Add("/dir/files_*.hipo");//To creat rcdb data RCDB_HOME must be set prior to installation
+      chain.WriteRcdbData("rcdb.root"); //Must use this first time to create local copy
+      //Then when we have local copy can just use the following
+      chain.SetRcdbFile("rcdb.root");
+
+
+See also Ex1_CLAS12ReaderChain.C for the relevent lines.

--- a/RunRoot/Ex1_CLAS12ReaderChain.C
+++ b/RunRoot/Ex1_CLAS12ReaderChain.C
@@ -45,11 +45,17 @@ void Ex1_CLAS12ReaderChain(){
    int counter=0;
    
    clas12root::HipoChain chain;
-   chain.Add("/WHERE/IS/MY/HIPO/file1.hipo");
+   chain.Add("/work/jlab/clas12data/pass0/skim3_005424.hipo");
+   // chain.Add("/WHERE/IS/MY/HIPO/file1.hipo");
    // chain.Add("/WHERE/IS/MY/HIPO/file2.hipo");
    // chain.Add("/WHERE/IS/MY/HIPO/file*.hipo");
    
-   
+   //////////////////////////////////////
+  //To creat rcdb data RCDB_HOME must be set prior to installation
+  //chain.WriteRcdbData("rcdb.root"); //Must use this first time to create local copy
+  //Then when we have local copy can just use the following
+  //chain.SetRcdbFile("rcdb.root");
+
    auto c12=chain.GetC12Reader();
    //c12->scalerReader();//if you want integrated charge
    //Add some event Pid based selections
@@ -62,14 +68,13 @@ void Ex1_CLAS12ReaderChain(){
    //////c12->addZeroOfRestPid();  //nothing else
    //////c12->useFTBased(); //and use the Pids from RECFT
 
-   
    while (chain.Next()){
      c12=chain.GetC12Reader();
-      
+     if(counter++>1E5) break;
      
      //c12->event()->getStartTime();
      
-     
+     //  cout<<c12->getRcdbVals().beam_energy<<endl;;
      //Loop over all particles to see how to access detector info.
      
      for(auto& p : c12->getDetParticles()){

--- a/RunRoot/Ex3_ProofLite.C
+++ b/RunRoot/Ex3_ProofLite.C
@@ -10,5 +10,11 @@
   chain.Add("/WHERE/IS/MY/HIPO/file.hipo");
   clas12root::myFirstSelector sel(&chain);
 
+  //////////////////////////////////////
+  //To creat rcdb data RCDB_HOME must be set prior to installation
+  //chain.WriteRcdbData("rcdb.root"); //Must use this first time to create local copy
+  //Then when we have local copy can just use the following
+  //chain.SetRcdbFile("rcdb.root");
+
   gProof->Process(&sel,chain.GetNRecords());
 }

--- a/RunRoot/Ex3b_TestSelector.C
+++ b/RunRoot/Ex3b_TestSelector.C
@@ -1,5 +1,5 @@
 //usage :
-//clas12proof  4 RunRoot/testSelector.C+ Ex3b_TestSelector.C
+//clas12proof  4 RunRoot/testSelector.C+ RunRoot/Ex3b_TestSelector.C
 //Where 4  is however many workers you would like
 //myFirstSelector.C is the source dode of the selector
 //   this can be created with any name using makeHipoSelector executable
@@ -7,9 +7,15 @@
 //selector name
 {
   clas12root::HipoChain chain;
-  // chain.Add("/work/jlab/clas12data/dst_skim4_5038.hipo ");
+  //chain.Add("/work/jlab/clas12data/pass0/skim3_005424.hipo");
   chain.Add("/WHERE/IS/MY/HIPO/FILE.hipo");
   clas12root::testSelector sel(&chain);
 
-  gProof->Process(&sel,chain.GetNRecords());
+  
+  //chain.WriteRcdbData("rcdb.root");
+  //chain.SetRcdbFile("rcdb.root");
+
+  chain.GetNRecords();
+  gProof->Process(&sel,100);
+  //gProof->Process(&sel,chain.GetNRecords());
 }

--- a/RunRoot/Ex5_CLAS12Writer2.C
+++ b/RunRoot/Ex5_CLAS12Writer2.C
@@ -1,0 +1,115 @@
+#include <cstdlib>
+#include <iostream>
+#include <chrono>
+#include <TFile.h>
+#include <TTree.h>
+#include <TApplication.h>
+#include <TROOT.h>
+#include <TDatabasePDG.h>
+#include <TLorentzVector.h>
+#include <TH1.h>
+#include <TChain.h>
+#include <TCanvas.h>
+#include <TBenchmark.h>
+#include "clas12reader.h"
+#include "clas12writer.h"
+
+using namespace clas12;
+
+
+void SetLorentzVector(TLorentzVector &p4,clas12::region_part_ptr rp){
+  p4.SetXYZM(rp->par()->getPx(),rp->par()->getPy(),
+	      rp->par()->getPz(),p4.M());
+
+}
+
+void Ex5_CLAS12Writer2(){
+  // Record start time
+  auto start = std::chrono::high_resolution_clock::now();
+
+
+  /////////////////////////////////////
+  //ignore this just getting input and output file names!
+  std::string inFile;
+  std::string outputFile;
+
+
+  std::cout<<"*** please type in an input file name"<<std::endl;
+  getline (cin, inFile);
+  if(inFile.find(".hipo")==std::string::npos){
+    std::cout<<" *** the input file must be a hipo file..."<<std::endl;
+    exit(0);
+  }
+  std::cout<<"*** please type in an output file name"<<std::endl;
+  getline (cin, outputFile);
+  if(outputFile.find(".hipo")==std::string::npos){
+    std::cout<<" *** the output file must be a hipo file..."<<std::endl;
+    exit(0);
+  }
+
+  /////////////////////////////////////
+
+  //initialising clas12writer with path to output file
+  clas12writer c12writer(outputFile.c_str());
+
+  //can as writer not to write certain banks
+  c12writer.skipBank("REC::Cherenkov");
+  c12writer.skipBank("REC::Traj");
+  c12writer.skipBank("REC::CovMat");
+
+  cout<<"Analysing hipo file "<<inFile<<endl;
+
+  //some particles
+  auto db=TDatabasePDG::Instance();
+  TLorentzVector beam(0,0,10.6,10.6);
+  TLorentzVector target(0,0,0,db->GetParticle(2212)->Mass());
+  TLorentzVector el(0,0,0,db->GetParticle(11)->Mass());
+  TLorentzVector pr(0,0,0,db->GetParticle(2212)->Mass());
+  TLorentzVector g1(0,0,0,0);
+  TLorentzVector g2(0,0,0,0);
+  TLorentzVector pip(0,0,0,db->GetParticle(211)->Mass());
+  TLorentzVector pim(0,0,0,db->GetParticle(-211)->Mass());
+   
+  gBenchmark->Start("timer");
+ 
+  int counter = 0;
+  int writeCounter = 0;
+   
+
+  //create the event reader
+  clas12reader c12(inFile.c_str());
+
+  //assign a reader to the writer
+  c12writer.assignReader(c12);
+     
+      
+  while(c12.next()==true){
+
+    // get particles by type
+    auto electrons=c12.getByID(11);
+    auto gammas=c12.getByID(22);
+    auto protons=c12.getByID(2212);
+    auto pips=c12.getByID(211);
+    auto pims=c12.getByID(-211);
+       
+    if(electrons.size()>0 &&pips.size()>0 &&pims.size()>0){
+       
+    
+	c12writer.writeEvent(); 
+
+      counter++;
+    }
+  }
+  
+
+  //close writer
+  c12writer.closeWriter();
+
+  gBenchmark->Stop("timer");
+  gBenchmark->Print("timer");
+  
+  auto finish = std::chrono::high_resolution_clock::now();
+  std::chrono::duration<double> elapsed = finish - start;
+  std::cout << "Elapsed time: " << elapsed.count()<< " read events = "<<counter<<" wrote events = "<<writeCounter<<" s\n";
+
+}

--- a/RunRoot/Ex8_RcdbReader.C
+++ b/RunRoot/Ex8_RcdbReader.C
@@ -9,6 +9,9 @@ using namespace clas12;
 using namespace std;
 
 void Ex8_RcdbReader(){
+  //This example shows how to use rcdb_reader class
+  //It is not expected that this will be required for
+  //general user who should just use clas12reader::queryRcdb()
 
   /* Creates the interface to RCDB header library.
    * Immediately opens a connection to rcdb@clasdb.jlab.org/rcdb.

--- a/RunRoot/Ex8b_RcdbReader.C
+++ b/RunRoot/Ex8b_RcdbReader.C
@@ -1,6 +1,5 @@
 #include <cstdlib>
 #include <iostream>
-#include "rcdb_reader.h"
 #include "clas12reader.h"
 #include <string>
 #include <chrono>
@@ -11,35 +10,16 @@ using namespace std;
 
 void Ex8b_RcdbReader(){
 
-
-  clas12reader c12("/a/hipo/file.hipo",{0});//needs tag-0 event
-  c12.next();//need to read first event
-  auto runNo=c12.runconfig()->getRun(); //get run number for this file
-  c12.getReader().gotoRecord(0); //reset back to start
+  /* The clas12reader opens a connection to the RCDB when it initialises.
+   * This connection is then closed but some run conditions are stored.
+   * This is done to avoid overloading the database.
+   */
+  clas12reader c12("/a/hipo/file.hipo");
   
-  /* Creates the interface to RCDB header library.
-   * Immediately opens a connection to rcdb@clasdb.jlab.org/rcdb.
-   */
-  rcdb_reader rcdb;
-
-  /* Examples of how to access different conditions for runNo.
-   * If the wrong type is asked for a given condition the code will 
-   * stop running.
-   * If the run or condition doesn't exist an error message is given 
-   * and a wrong value is returned.
-   * The database and conditions can be viewed at 
-   * https://clasweb.jlab.org/rcdb/ .
-   */
-  int val = rcdb.getIntValue(runNo, "event_count");
-  double val2 = rcdb.getDoubleValue(runNo, "beam_energy");
-  double val3 = rcdb.getDoubleValue(runNo, "beam_current");
-  std::string val4 = rcdb.getStringValue(runNo, "target");
-  bool val5 = rcdb.getBoolValue(runNo, "is_valid_run_end");
-
-  cout<<"Run number : "<<runNo<<endl;
-  cout<<"Event count: "<<val<<" Beam energy: "<<val2<<endl;
-  cout<<"Beam current: "<<val3<<" Target: "<<val4<<endl;
-  cout<<"Run is valid: "<<val5<<endl;
+  //The following run conditions can be returned directly by c12
+  cout<<"Event count: "<<c12.getRunCondition("event_count")<<endl;
+  cout<<"Beam energy: "<<c12.getRunCondition("beam_energy")<<endl;
+  cout<<"Beam current: "<<c12.getRunCondition("beam_current")<<endl;
 
 
 }

--- a/RunRoot/Ex8b_RcdbReader.C
+++ b/RunRoot/Ex8b_RcdbReader.C
@@ -15,11 +15,14 @@ void Ex8b_RcdbReader(){
    * This is done to avoid overloading the database.
    */
   clas12reader c12("/a/hipo/file.hipo");
+  c12.queryRcdb(); //only check rcdb values when asked to (and RCDB_HOME was set)
+  
+  auto rcdbData=c12.getRcdbVals();//struct with all relevent rcdb values
   
   //The following run conditions can be returned directly by c12
-  cout<<"Event count: "<<c12.getRunCondition("event_count")<<endl;
-  cout<<"Beam energy: "<<c12.getRunCondition("beam_energy")<<endl;
-  cout<<"Beam current: "<<c12.getRunCondition("beam_current")<<endl;
+  cout<<"Event count: "<<rcdbData.event_count<<endl;
+  cout<<"Beam energy: "<<rcdbData.beam_energy<<endl;
+  cout<<"Beam current: "<<rcdbData.beam_current<<endl;
 
 
 }

--- a/RunRoot/testSelector.C
+++ b/RunRoot/testSelector.C
@@ -66,6 +66,9 @@ namespace clas12root{
     _c12->addExactPid(-211,1);    //exactly 1 pi-
     _c12->addExactPid(2212,1);    //exactly 1 proton
     _c12->addExactPid(22,2);    //exactly 2 gamma
+
+    //cout<<"Using beam energy for rcdb "<<_c12->getRcdbVals().beam_energy<<endl;
+    // _beam.SetE(_c12->getRcdbVals().beam_energy/1000);
   }
   
   void SetLorentzVector(TLorentzVector &p4,clas12::region_part_ptr rp){


### PR DESCRIPTION
Create function clas12reader::readQuickRunConfig to read ahead and get file run number 
Create function clas12reader::queryRcdb() for 1 time read of database, connection closed after this and cannot be re-opened without creating another clas12reader
Create rcdb_vals struct containing all the conditions listed at https://clasweb.jlab.org/rcdb/conditions/
this is filled during queryRcdb()  and kept as a data member of clas12 reader so the user then has access to all rcdb info by using clas12reader::getRcdbVals()

Implement rcbd lookup in HipoChain for use in HipoSelector. In particular loop over all files and get rcdb information before processing hipo events. rcdb info is written locally to a root file and accessed during the selector processing whenever a new file is opened.
If an rcdb file is set then HipoChain automatically read the local root file and assigns rcdb_vals to clas12reader.
