### PR TITLE
protect ftbparticle against quieries when no entries, add region_part…

### DIFF
--- a/Clas12Banks/ftbparticle.h
+++ b/Clas12Banks/ftbparticle.h
@@ -50,15 +50,18 @@ namespace clas12 {
     float  getChi2Pid(int index)    const noexcept{ return getFloat(_chi2pid_order,index);}
     int    getStatus(int index)    const noexcept{ return getShort(_st_order,index);}
 
-    int    getPid()   const noexcept{ return getInt(_pid_order,_entry);}
-    float  getVt()    const noexcept{ return getFloat(_vt_order,_entry);}
-    float  getBeta()    const noexcept{ return getFloat(_beta_order,_entry);}
-    float  getChi2Pid()    const noexcept{ return getFloat(_chi2pid_order,_entry);}
-    int    getStatus()    const noexcept{ return getShort(_st_order,_entry);}
+    int    getPid()   const noexcept{ return _entry==-1?0:getInt(_pid_order,_entry);}
+    float  getVt()    const noexcept{ return _entry==-1?0:getFloat(_vt_order,_entry);}
+    float  getBeta()    const noexcept{ return _entry==-1?0:getFloat(_beta_order,_entry);}
+    float  getChi2Pid()    const noexcept{ return _entry==-1?0:getFloat(_chi2pid_order,_entry);}
+    int    getStatus()    const noexcept{ return _entry==-1?0:getShort(_st_order,_entry);}
 
  
     
-    void setEntry(short i){ _entry=i;}
+    void setEntry(short i){
+      if( i<getRows() )_entry=i;
+      else _entry = -1;
+    }
     void setBankEntry(short i){ _entry=i;} //faster for BankHist
     short getEntry() const  noexcept{return _entry;}
     /**

--- a/Clas12Banks/mcparticle.h
+++ b/Clas12Banks/mcparticle.h
@@ -82,7 +82,9 @@ namespace clas12 {
     }
     
     void setEntry(short i){
-      _entry=i;
+      if( i<getRows() )_entry=i;
+      else _entry = -1;
+      
       if(_match.get()!=nullptr)_match->setEntry(i);
     }
     void setBankEntry(short i){

--- a/Clas12Banks/region_particle.cpp
+++ b/Clas12Banks/region_particle.cpp
@@ -82,15 +82,15 @@ namespace clas12 {
     float mass= p/getBeta()/getGamma();
     return mass;
   }
-
-  float region_particle::getBeta() {
-    float t=getTime()-_event->getStartTime();
-    float d=getPath()/100;
-    if(t==0)
-      return 0;
-    float beta= d/t/2.9979246e+08*1E9;
-    return beta;
-  }
+  ////clashes with bank item
+  // float region_particle::getBeta() {
+  //   float t=getTime()-_event->getStartTime();
+  //   float d=getPath()/100;
+  //   if(t==0)
+  //     return 0;
+  //   float beta= d/t/2.9979246e+08*1E9;
+  //   return beta;
+  // }
   float region_particle::getGamma() {
     float beta=getBeta();
     float gamma= sqrt(1/(1-beta*beta));
@@ -131,6 +131,8 @@ namespace clas12 {
       return 0.00051099891;
     case -2212:
       return 0.93827200;
+    case 45:
+      return 1.875612;
     default :
       return 0;
     }

--- a/Clas12Banks/region_particle.h
+++ b/Clas12Banks/region_particle.h
@@ -65,11 +65,28 @@ namespace clas12 {
       return true;
     }
 
+    //solve FTB ambiguity at this stage
     int getPid(){
       _parts->setEntry(_pentry);
       return _useFTBPid*_ftbparts->getRows()?_ftbparts->getPid():_parts->getPid();
     }
-    
+    int getVt(){
+      _parts->setEntry(_pentry);
+      return _useFTBPid*_ftbparts->getRows()?_ftbparts->getVt():_parts->getVt();
+    }
+    int getStatus(){
+      _parts->setEntry(_pentry);
+      return _useFTBPid*_ftbparts->getRows()?_ftbparts->getStatus():_parts->getStatus();
+    }
+    int getChi2Pid(){
+      _parts->setEntry(_pentry);
+      return _useFTBPid*_ftbparts->getRows()?_ftbparts->getChi2Pid():_parts->getChi2Pid();
+    }
+    int getBeta(){
+      _parts->setEntry(_pentry);
+      return _useFTBPid*_ftbparts->getRows()?_ftbparts->getBeta():_parts->getBeta();
+    }
+ 
     virtual double getTime()=0;
     virtual double getPath()=0;
     virtual double getDetEnergy()=0;
@@ -97,7 +114,7 @@ namespace clas12 {
     float getPhi() const;
     float getP(){_parts->setEntry(_pentry);return _parts->getP();}
     float getCalcMass();
-    float getBeta();
+    //float getBeta();
     float getGamma();
     float getDeltaTime();
     float getBetaFromP();


### PR DESCRIPTION
…icle functions to handle ambigous data i.e
 p->getStatus() rather than 
p->par()->getStatus() or p->ftbpar()->getStatus()