### PR TITLE
qadb inline functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,12 +38,7 @@ set(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 #include clasqaDB c++ library and rapidjson library
 IF (DEFINED ENV{QADB})
-
-  include_directories($ENV{QADB}/srcC/rapidjson/include)
   include_directories($ENV{QADB}/srcC/include)
-  #clasqaDB header contains function definitions which are not inlined
-  #including this header causes multiple definitions of these functions
-  set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS}  -Wl,--allow-multiple-definition")
   add_definitions(-DCLAS_QADB)
 ENDIF (DEFINED ENV{QADB})
 

--- a/Clas12Banks/qadb_reader.h
+++ b/Clas12Banks/qadb_reader.h
@@ -75,7 +75,7 @@ namespace clas12 {
     double getAccCharge(){return _qa.GetAccumulatedCharge();};
 
   private: 
-    QADB _qa;//!  
+    QA::QADB _qa;//!  
 
 #else
   public:

--- a/Clas12Banks/region_particle.h
+++ b/Clas12Banks/region_particle.h
@@ -70,7 +70,7 @@ namespace clas12 {
       _parts->setEntry(_pentry);
       return _useFTBPid*_ftbparts->getRows()?_ftbparts->getPid():_parts->getPid();
     }
-    int getVt(){
+    float getVt(){
       _parts->setEntry(_pentry);
       return _useFTBPid*_ftbparts->getRows()?_ftbparts->getVt():_parts->getVt();
     }
@@ -78,11 +78,11 @@ namespace clas12 {
       _parts->setEntry(_pentry);
       return _useFTBPid*_ftbparts->getRows()?_ftbparts->getStatus():_parts->getStatus();
     }
-    int getChi2Pid(){
+    float getChi2Pid(){
       _parts->setEntry(_pentry);
       return _useFTBPid*_ftbparts->getRows()?_ftbparts->getChi2Pid():_parts->getChi2Pid();
     }
-    int getBeta(){
+    float getBeta(){
       _parts->setEntry(_pentry);
       return _useFTBPid*_ftbparts->getRows()?_ftbparts->getBeta():_parts->getBeta();
     }


### PR DESCRIPTION
We need to use namespace QA in qadb_reader 
We can remove use_multiple_defitions from cmake