### PR TITLE
particleTree CreateBankLink

### DIFF
--- a/Clas12Banks/vertdoca.h
+++ b/Clas12Banks/vertdoca.h
@@ -60,7 +60,7 @@ namespace clas12 {
     }
   
     int getCombinationEntry(const int index1,const int index2){
-      for(uint i=0;i<getSize();++i){
+      for(int i=0;i<getSize();++i){
 	auto i1= getIndex1(i);
 	auto i2= getIndex2(i);
 	if(i1==index1&&i2==index2)

--- a/Clas12Root/HipoROOTOut.h
+++ b/Clas12Root/HipoROOTOut.h
@@ -47,6 +47,11 @@ namespace clas12root {
 
     void SetEntries(Long64_t n){_nEntriesToProcess=n;}
     void SetVerbose(short v=1){_verbose=v;}
+
+    void CreateBankLink(TString label,TString code){
+      _mapOfParts[label]=code;
+    }
+    
   protected :
     
     TString _tempActionName;

--- a/Clas12Root/ParticleTree.h
+++ b/Clas12Root/ParticleTree.h
@@ -34,7 +34,8 @@ namespace clas12root {
     }
 
     void UseEventData(){_useEventData=kTRUE;}
-  private :
+
+   private :
    std::map<short,short> _pidSelect;
    std::map<short,short> _pidSelectExact;
    bool _zeroOfRestPid=false;

--- a/README.md
+++ b/README.md
@@ -308,6 +308,16 @@ You can perform some arithmetic and define a new branch e.g.
     	treemaker.Branch("P.Time-EVNT.StartTime/F","Time"); //branch name Time
   	treemaker.Branch("P.Time-EVNT.FTBStartTime/F","FTBTime"); //branch name FTBTime
 
+Or for banks without links create one yourself, this is useful for trajectories which require specific detector elements.
+
+!!!! WARNING the label e.g. TRAJFTOFFTOF1A must only contain alphanumeric characters !!!!!
+
+     treemaker.CreateBankLink("TRAJFTOFFTOF1A","p->traj(FTOF,FTOF1A)->");
+     treemaker.Branch("TRAJFTOFFTOF1A.X/F");
+     treemaker.Branch("TRAJFTOFFTOF1A.Y/F");
+     treemaker.Branch("TRAJFTOFFTOF1A.Z/F");
+
+You can also add standard clas12root filtering
 
      treemaker.AddExactPid(11,1); //filter events with exactly 1 e-
      treemaker.AddAtLeastPid(211,1);//and at least 1 pi+

--- a/RunRoot/Ex4_TreeMaker.C
+++ b/RunRoot/Ex4_TreeMaker.C
@@ -22,6 +22,14 @@
   treemaker.Branch("PBANK.Pid/I");
   //treemaker.Branch("PBANK.FTBPid/I");//FT based PID
 
+  //Or for banks without links create one yourself
+  //Useful for trajectories which require specific detector elements
+  //!!!! WARNING the label e.g. TRAJFTOFFTOF1A must only contain alphanumeric characters !!!!!
+  //treemaker.CreateBankLink("TRAJFTOFFTOF1A","p->traj(FTOF,FTOF1A)->");
+  //treemaker.Branch("TRAJFTOFFTOF1A.X/F");
+  //treemaker.Branch("TRAJFTOFFTOF1A.Y/F");
+  //treemaker.Branch("TRAJFTOFFTOF1A.Z/F");
+
   //e.g. Only save electron information
   // treemaker.AddParticleCut("PBANK.Pid==11");
 


### PR DESCRIPTION
Add flexibility to add new links to banks for particleDraw and particleTree, e.g

     treemaker.CreateBankLink("TRAJFTOFFTOF1A","p->traj(FTOF,FTOF1A)->");
     treemaker.Branch("TRAJFTOFFTOF1A.X/F");
     treemaker.Branch("TRAJFTOFFTOF1A.Y/F");
     treemaker.Branch("TRAJFTOFFTOF1A.Z/F");
