### PR TITLE
add rapidjson to includes list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,7 @@ set(CMAKE_INSTALL_INCLUDEDIR ${CMAKE_CURRENT_SOURCE_DIR}/include)
 #include clasqaDB c++ library and rapidjson library
 IF (DEFINED ENV{QADB})
   include_directories($ENV{QADB}/srcC/include)
+  include_directories($ENV{QADB}/srcC/rapidjson/include)
   add_definitions(-DCLAS_QADB)
 ENDIF (DEFINED ENV{QADB})
 


### PR DESCRIPTION
Not sure if others had this issue, but I had to add `rapidjson` headers to the included directories, otherwise `cmake` couldn't find them. My `$QADB` variable is set to a separate `clasqaDB` directory (i.e., not the submodule).