### PR TITLE
Small changes to how path and time are set for neutrals

### DIFF
--- a/Clas12Banks/region_fdet.h
+++ b/Clas12Banks/region_fdet.h
@@ -51,7 +51,7 @@ namespace clas12 {
      
 
     double getTime() final{
-      if(_ptof>-1){
+      if(_ptof>-1 && par()->getCharge()!=0){
 	_scint->setIndex(_ptof);
 	return _scint->getTime();
       }
@@ -59,7 +59,7 @@ namespace clas12 {
       return _cal->getTime();
     }
     double getPath() final{
-      if(_ptof>-1){
+      if(_ptof>-1 && par()->getCharge()!=0){
 	_scint->setIndex(_ptof);
 	return _scint->getPath();
       }


### PR DESCRIPTION
For neutrals in the forward detector the path and time variables should only be taken from the calorimeters and not the FTOF. This is how the reconstruction does it, and not all neutrals will have a hit in the FTOF.