### PR TITLE
rich fix

### DIFF
--- a/Clas12Banks/particle_detector.h
+++ b/Clas12Banks/particle_detector.h
@@ -70,8 +70,8 @@ namespace clas12 {
     ////////////////////////////////////////////////////////////////
     //override header notify, called at start of event
     void notify() override {
-      if(_detector_id_order==-1) return;
       bank::notify();
+      if(_detector_id_order==-1) return;
       scanIndex();
     }
 


### PR DESCRIPTION
Rich getRows was always -1
Was fixed by changing the position of hipo::bank::notify in particle_detector, which was wrongly behind an if statement which failed for rich.
Something must have changed in a recent hipo version to bring this to light.
