### PR TITLE
ci: test HIPO 4.2.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,7 +32,7 @@ jobs:
       - name: build hipo
         run: |
           meson setup hipo_build hipo_src --prefix=$(pwd)/hipo_install
-          meson install -C build
+          meson install -C hipo_build
           tar cavf hipo_install{.tar.zst,}
       - uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,6 +21,7 @@ jobs:
           apt -y upgrade
           apt -y install git python2 python-pip
           python2 -m pip install scons
+          python -m pip install meson ninja # for HIPO
 
       - name: checkout repository
         uses: actions/checkout@v4
@@ -48,15 +49,14 @@ jobs:
       - name: checkout hipo
         uses: actions/checkout@v4
         with:
-          repository: gavalian/hipo
-          ref: 4.0.1 # if you want to use a fixed tag; remove if you want to use `main`
+          repository: c-dilks/hipo
+          ref: fix-meson # if you want to use a fixed tag; remove if you want to use `main`
           path: hipo_src
 
       - name: build hipo
         run: |
-          cmake -S hipo_src -B hipo_build --install-prefix $HIPO
-          cmake --build hipo_build
-          cmake --install hipo_build
+          meson setup hipo_build hipo_src --prefix=$HIPO
+          meson install -C build
 
       - name: build ccdb
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -21,7 +21,9 @@ jobs:
           apt -y upgrade
           apt -y install git python2 python-pip
           python2 -m pip install scons
-          python -m pip install meson ninja # for HIPO
+          python2 -m pip install meson ninja # for HIPO
+          echo "===== VERSIONS ====="
+          for pkg in scons cmake meson ninja; do echo "$pkg: $($pkg --version)"; done
 
       - name: checkout repository
         uses: actions/checkout@v4

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,12 +33,12 @@ jobs:
         run: |
           meson setup hipo_build hipo_src --prefix=$(pwd)/hipo_install
           meson install -C hipo_build
-          tar cavf hipo_install{.tar.zst,}
+          tar cavf hipo_install{.tar.gz,}
       - uses: actions/upload-artifact@v4
         with:
           name: hipo_install-${{ matrix.version }}
           retention-days: 5
-          path: hipo_install.tar.zst
+          path: hipo_install.tar.gz
 
 
   build_and_test:
@@ -83,7 +83,7 @@ jobs:
 
       - name: extract HIPO installation
         run: |
-          tar xvf hipo_install.tar.zst
+          tar xvf hipo_install.tar.gz
           mkdir -p $HIPO
           mv hipo_install/* $HIPO/
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,7 @@ jobs:
 
 
   build_and_test:
+    needs: [build_hipo]
     runs-on: ubuntu-latest
     container: rootproject/root:${{ matrix.version }}
     strategy:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,40 @@ defaults:
     shell: bash
 
 jobs:
+
+  build_hipo:
+    runs-on: ubuntu-latest
+    container: rootproject/root:${{ matrix.version }}
+    strategy:
+      matrix:
+        version: [6.28.12-ubuntu22.04]
+    steps:
+      - name: system dependencies
+        run: |
+          apt -y update
+          apt -y upgrade
+          apt -y install git python3-pip
+          python -m pip install meson ninja
+          echo "===== VERSIONS ====="
+          for pkg in meson ninja; do echo "$pkg: $($pkg --version)"; done
+      - name: checkout hipo
+        uses: actions/checkout@v4
+        with:
+          repository: c-dilks/hipo ##### FIXME: should be `master`
+          ref: fix-meson # if you want to use a fixed tag; remove if you want to use `main`
+          path: hipo_src
+      - name: build hipo
+        run: |
+          meson setup hipo_build hipo_src --prefix=hipo_install
+          meson install -C build
+          tar cavf hipo_install{.tar.zst,}
+      - uses: actions/upload-artifact@v4
+        with:
+          name: hipo_install-${{ matrix.version }}
+          retention-days: 5
+          path: hipo_install.tar.zst
+
+
   build_and_test:
     runs-on: ubuntu-latest
     container: rootproject/root:${{ matrix.version }}
@@ -19,11 +53,8 @@ jobs:
         run: |
           apt -y update
           apt -y upgrade
-          apt -y install git python2 python-pip python3-pip
+          apt -y install git python2 python-pip
           python2 -m pip install scons
-          python3 -m pip install meson ninja # for HIPO
-          echo "===== VERSIONS ====="
-          for pkg in scons cmake meson ninja; do echo "$pkg: $($pkg --version)"; done
 
       - name: checkout repository
         uses: actions/checkout@v4
@@ -44,21 +75,16 @@ jobs:
           echo "PATH=$PWD/bin:$CCDB_HOME:$CCDB_HOME/bin:$RCDB_HOME/bin:$RCDB_HOME/cpp/bin:$PATH" >> $GITHUB_ENV
           echo "LD_LIBRARY_PATH=$RCDB_HOME/cpp/lib:$CCDB_HOME/lib:$LD_LIBRARY_PATH" >> $GITHUB_ENV
 
-      - name: Create hipo folder
-        run: |
-          mkdir -p $HIPO
-
-      - name: checkout hipo
-        uses: actions/checkout@v4
+      - name: get HIPO installation
+        uses: actions/download-artifact@v4
         with:
-          repository: c-dilks/hipo
-          ref: fix-meson # if you want to use a fixed tag; remove if you want to use `main`
-          path: hipo_src
+          name: hipo_install-${{ matrix.version }}
 
-      - name: build hipo
+      - name: extract HIPO installation
         run: |
-          meson setup hipo_build hipo_src --prefix=$HIPO
-          meson install -C build
+          tar xvf hipo_install.tar.zst
+          mkdir -p $HIPO
+          mv hipo_install/* $HIPO/
 
       - name: build ccdb
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,9 +19,9 @@ jobs:
         run: |
           apt -y update
           apt -y upgrade
-          apt -y install git python2 python-pip
+          apt -y install git python2 python-pip python3-pip
           python2 -m pip install scons
-          python2 -m pip install meson ninja # for HIPO
+          python3 -m pip install meson ninja # for HIPO
           echo "===== VERSIONS ====="
           for pkg in scons cmake meson ninja; do echo "$pkg: $($pkg --version)"; done
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,7 @@ jobs:
           path: hipo_src
       - name: build hipo
         run: |
-          meson setup hipo_build hipo_src --prefix=hipo_install
+          meson setup hipo_build hipo_src --prefix=$(pwd)/hipo_install
           meson install -C build
           tar cavf hipo_install{.tar.zst,}
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
HIPO 4.2's build system will be Meson (https://github.com/gavalian/hipo/pull/59); this PR tests if clas12root can successfully consume it.