### PR TITLE
build: use Nathan's CCDB fork

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,8 +19,8 @@ jobs:
         run: |
           apt -y update
           apt -y upgrade
-          apt -y install git python2 python-pip
-          python2 -m pip install scons
+          apt -y install git python3-pip
+          python -m pip install scons
 
       - name: checkout repository
         uses: actions/checkout@v4
@@ -62,7 +62,7 @@ jobs:
         run: |
           cd $CCDB_HOME
           source environment.bash
-          python2 $(which scons)
+          python $(which scons)
 
       - name: build clas12root
         run: |

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,6 @@
 [submodule "clas12-qadb"]
 	path = clas12-qadb
 	url = https://github.com/JeffersonLab/clas12-qadb
+[submodule "ccdb"]
+	path = ccdb
+	url = https://github.com/baltzell/ccdb.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "lz4"]
 	path = lz4
 	url = https://github.com/lz4/lz4.git
-[submodule "ccdb"]
-	path = ccdb
-	url = https://github.com/JeffersonLab/ccdb.git
 [submodule "rcdb"]
 	path = rcdb
 	url = https://github.com/JeffersonLab/rcdb


### PR DESCRIPTION
This PR switches the CCDB submodule to use @baltzell's fork of CCDB, which is the version we use in other CLAS12 software.