### PR TITLE
deps: update `rcdb` submodule to v1.99.6

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -10,3 +10,6 @@
 [submodule "hipo_src"]
 	path = hipo_src
 	url = https://github.com/gavalian/hipo.git
+[submodule "rcdb"]
+	path = rcdb
+	url = https://github.com/baltzell/rcdb.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,6 @@
 [submodule "lz4"]
 	path = lz4
 	url = https://github.com/lz4/lz4.git
-[submodule "rcdb"]
-	path = rcdb
-	url = https://github.com/JeffersonLab/rcdb
 [submodule "clas12-qadb"]
 	path = clas12-qadb
 	url = https://github.com/JeffersonLab/clas12-qadb


### PR DESCRIPTION
This isn't an offical `rcdb` tag, but this is the version deployed as module `rcdb/1.99.6` (@baltzell correct me if I'm wrong).