### PR TITLE
fix: `qadb_reader` instantiation when `CLAS_QADB` is not defined

### DIFF
--- a/Clas12Banks/qadb_reader.cpp
+++ b/Clas12Banks/qadb_reader.cpp
@@ -90,7 +90,7 @@ namespace clas12 {
   }
 
 #else
-  qadb_reader::qadb_reader(int runNb){
+  qadb_reader::qadb_reader(const string& pass,int runNb){
     _runNb=runNb;
   }
 


### PR DESCRIPTION
Adds a missing required argument.