### PR TITLE
fix: support CMake v4

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.0 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project(clas12hipo4root)
 
 	


### PR DESCRIPTION
CMake v4.0.0 was recently released, and support for versions < 3.5 has been dropped. This PR raises the minimum supported CMake version in the CMake config, assuming that no CMake code is specific to versions <3.5.