### PR TITLE
fix(ci): tab -> space

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
         uses: actions/checkout@v4
       - name: build clas12root
         run: |
-	  echo 'check hipo:'
+          echo 'check hipo:'
           ./installC12Root
 
       - name: run example on data file


### PR DESCRIPTION
Change a `tab` to an equivalent number of spaces in the CI YAML.
This `tab` was preventing CI from running!