### PR TITLE
fix(ci): don't `apt upgrade`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,7 +18,6 @@ jobs:
       - name: system dependencies
         run: |
           apt -y update
-          apt -y upgrade
           apt -y install git python3-pip
           python -m pip install --break-system-packages meson ninja
 


### PR DESCRIPTION
since it triggers updates for unrelated packages, and sometimes failures such as [this one, seen in `coatjava` CI](https://github.com/JeffersonLab/coatjava/actions/runs/17418515756/job/49452235710)

on the other hand, `apt update` is recommended by the CI documentation