### PR TITLE
doc: link to Iguana tutorial slides

### DIFF
--- a/README.md
+++ b/README.md
@@ -578,10 +578,13 @@ Note the event number is just its position in the file, not the DST RUN::Config:
 
 ## Ex 11 Iguana interface
 
-To run iguana routines in clas12root you should first set the environment to point to an
+To run iguana routines in Clas12root you should first set the environment to point to an
 installed version of iguana, by setting the `IGUANA` variable to the INSTALLATION directory.
 Clas12root does _not_ depend on Iguana, but running `clas12root` will load its libraries for you if
 you have set the `IGUANA` environment variable.
 
 For usage of Iguana with `clas12root`, see the examples, such as
 - [`Ex11_Iguana.C`](/RunRoot/Ex11_Iguana.C)
+
+For tutorial slides, which illustrate how Iguana is used with Clas12root, see:
+- [Tutorial Slides (Software Meeting 15 January 2026)](https://clasweb.jlab.org/wiki/index.php/File:Iguana-and-clas12root.pdf)

--- a/RunRoot/Ex11_Iguana.C
+++ b/RunRoot/Ex11_Iguana.C
@@ -30,19 +30,23 @@
 
 void Ex11_Iguana() {
 
-  // parse arguments, which should be HIPO filename(s) prefixed with `--in=`; add them to a `HipoChain`
+  // create a HipoChain
   clas12root::HipoChain chain;
-  for(int i=2; i<gApplication->Argc(); i++) {
-    TString inputFile = gApplication->Argv(2);
-    inputFile(TRegexp("^--in=")) = "";
-    std::cout << "reading file " << inputFile << std::endl;
-    chain.Add(inputFile);
-    chain.SetReaderTags({0}); // read tag-0 events only
+
+  // parse CLI arguments
+  for(Int_t i = 2; i < gApplication->Argc(); i++) {
+    // if the argument starts with `--in=` and ends with `.hipo`, assume it's a HIPO file and add it to `chain`
+    if(TString opt = gApplication->Argv(i); opt.Contains(TRegexp("^--in=.*\\.hipo$"))) {
+      opt.ReplaceAll("--in=", "");
+      std::cout << "Add file " << opt << std::endl;
+      chain.Add(opt);
+    }
   }
-  if(chain.GetNFiles() == 0) {
-    std::cerr << " *** please provide HIPO file name(s)" << std::endl;
-    exit(1);
-  }
+  if(chain.GetNFiles() == 0)
+    throw std::runtime_error("please provide HIPO file name(s): --in=file1.hipo --in=file2.hipo ...");
+
+  // read tag-0 (physics) events only
+  chain.SetReaderTags({0}); // read tag-0 events only
 
   //////////////////////////////////////////////////////////////////////////////////
 


### PR DESCRIPTION
- add a link to the tutorial slides presented at the latest software meeting
- clean up the CLI argument parsing in the example (which also fixes its argument parsing)